### PR TITLE
Add a rudimentary checks for PRs

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,35 @@
+name: Check PR
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - synchronize
+    branches:
+      - 'master*'
+      - 'release*'
+
+jobs:
+  check-pr:
+    name: Check PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit messages for WIP
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(?!WIP)'
+          flags: 'gmi'
+          error: Work in progress
+          checkAllCommitMessages: true
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check PR labels
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          valid-labels: 'merge'
+          invalid-labels: 'do-not-merge, wip, wait-before-merge'
+          disable-reviews: true
+          github-token: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
This adds a workflow for rudimentary checks on PRs:
* "merge" label has to be set
* "wip", "do-not-merge", "wait-before-merge" labels are not allowed
* commit messages must not contain "WIP/wip"