### PR TITLE
Consider pull request target when running checks

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -11,6 +11,17 @@ on:
     branches:
       - 'master*'
       - 'release*'
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - synchronize
+    branches:
+      - 'master*'
+      - 'release*'
 
 jobs:
   check-pr:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,10 @@ on:
     branches:
       - 'master*'
       - 'release*'
+  pull_request_target:
+    branches:
+      - 'master*'
+      - 'release*'
 
 env:
   GOPROXY: https://proxy.golang.org


### PR DESCRIPTION
Currently, only `pull_request` is considered when running the checks. With this change the check also run on `pull_request_target`.