### PR TITLE
Use git clone for full checkout

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,11 +44,9 @@ jobs:
           go-version: 1.15.8
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2
@@ -81,11 +79,9 @@ jobs:
           go-version: 1.15.8
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2
@@ -118,11 +114,9 @@ jobs:
           go-version: 1.15.8
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
 
   build-linux-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
@@ -70,7 +70,7 @@ jobs:
 
   build-macos-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: macos-10.15
     steps:
       - name: Set up go
@@ -105,7 +105,7 @@ jobs:
 
   build-windows-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: windows-2019
     steps:
       - name: Set up go
@@ -140,7 +140,7 @@ jobs:
 
   verify:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -103,41 +103,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  build-windows-amd64:
-    needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: windows-2019
-    steps:
-      - name: Set up go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.15.8
-
-      - name: Checkout full
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
-
-      - name: Checkout shallow
-        uses: actions/checkout@v2
-        if: startsWith(github.ref, 'refs/tags/') == false
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-
-      - name: Make kops examples test
-        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-        run: |
-          make kops examples test-windows
-
-      - name: Upload windows binary
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v2
-        with:
-          name: kops-windows-amd64
-          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/local/kops
-          if-no-files-found: error
-          retention-days: 1
-
   verify:
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
@@ -164,7 +129,6 @@ jobs:
     needs:
       - build-linux-amd64
       - build-macos-amd64
-      - build-windows-amd64
       - verify
     steps:
       - name: Download all kops binary artifacts
@@ -174,7 +138,6 @@ jobs:
         run: |
           mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
           mv kops-darwin-amd64/kops kops-darwin-amd64/kops-darwin-amd64
-          mv kops-windows-amd64/kops kops-windows-amd64/kops-windows-amd64
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -183,4 +146,3 @@ jobs:
           files: |
             kops-linux-amd64/kops-linux-amd64
             kops-darwin-amd64/kops-darwin-amd64
-            kops-windows-amd64/kops-windows-amd64


### PR DESCRIPTION
This uses `git clone` instead of the checkout action to clone the git repository, to make it possible for `git describe --always` to find the right tag/branch.