### PR TITLE
One server group for masters (based on V1.22.1)

### DIFF
--- a/pkg/model/openstackmodel/servergroup.go
+++ b/pkg/model/openstackmodel/servergroup.go
@@ -240,13 +240,24 @@ func (b *ServerGroupModelBuilder) Build(c *fi.ModelBuilderContext) error {
 		} else {
 			affinityPolicies = append(affinityPolicies, "anti-affinity")
 		}
+
+		sgName := s(fmt.Sprintf("%s-%s", clusterName, ig.Name))
+
+		var backingSGName *string
+		if v, ok := ig.ObjectMeta.Annotations[openstack.OS_ANNOTATION+openstack.BACKING_SERVER_GROUP_NAME]; ok {
+			backingSGName = s(fmt.Sprintf("%s-%s", clusterName, v))
+		} else {
+			backingSGName = sgName
+		}
+
 		sgTask := &openstacktasks.ServerGroup{
-			Name:        s(fmt.Sprintf("%s-%s", clusterName, ig.Name)),
-			ClusterName: s(clusterName),
-			IGName:      s(ig.Name),
-			Policies:    affinityPolicies,
-			Lifecycle:   b.Lifecycle,
-			MaxSize:     ig.Spec.MaxSize,
+			Name:          sgName,
+			BackingSGName: backingSGName,
+			ClusterName:   s(clusterName),
+			IGName:        s(ig.Name),
+			Policies:      affinityPolicies,
+			Lifecycle:     b.Lifecycle,
+			MaxSize:       ig.Spec.MaxSize,
 		}
 		c.AddTask(sgTask)
 

--- a/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-additional-security-groups.yaml
@@ -62,6 +62,7 @@ SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups:
 - additional-sg
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -211,6 +212,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-ClusterSpec.yaml
@@ -61,6 +61,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -209,6 +210,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/adds-cloud-labels-from-InstanceGroupSpec.yaml
@@ -61,6 +61,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -209,6 +210,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/configures-server-group-affinity-with-annotations.yaml
@@ -60,6 +60,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -208,6 +209,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-auto-zone-distribution.yaml
@@ -120,6 +120,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -207,6 +208,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -294,6 +296,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -372,6 +375,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -450,6 +454,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -528,6 +533,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -859,6 +865,7 @@ Tags:
 - KopsName=port-node-3
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master
 ClusterName: cluster
 ID: null
 IGName: master
@@ -868,6 +875,7 @@ Name: cluster-master
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion-with-API-loadbalancer.yaml
@@ -119,6 +119,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-a
   ClusterName: cluster
   ID: null
   IGName: master-a
@@ -194,6 +195,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-b
   ClusterName: cluster
   ID: null
   IGName: master-b
@@ -269,6 +271,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-c
   ClusterName: cluster
   ID: null
   IGName: master-c
@@ -347,6 +350,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-a
   ClusterName: cluster
   ID: null
   IGName: node-a
@@ -425,6 +429,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-b
   ClusterName: cluster
   ID: null
   IGName: node-b
@@ -503,6 +508,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-c
   ClusterName: cluster
   ID: null
   IGName: node-c
@@ -749,6 +755,7 @@ Pool:
   Name: master-public-name-https
 ProtocolPort: 443
 ServerGroup:
+  BackingSGName: cluster-master-a
   ClusterName: cluster
   ID: null
   IGName: master-a
@@ -782,6 +789,7 @@ Pool:
   Name: master-public-name-https
 ProtocolPort: 443
 ServerGroup:
+  BackingSGName: cluster-master-b
   ClusterName: cluster
   ID: null
   IGName: master-b
@@ -815,6 +823,7 @@ Pool:
   Name: master-public-name-https
 ProtocolPort: 443
 ServerGroup:
+  BackingSGName: cluster-master-c
   ClusterName: cluster
   ID: null
   IGName: master-c
@@ -1010,6 +1019,7 @@ Tags:
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master-a
 ClusterName: cluster
 ID: null
 IGName: master-a
@@ -1019,6 +1029,7 @@ Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-b
 ClusterName: cluster
 ID: null
 IGName: master-b
@@ -1028,6 +1039,7 @@ Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-c
 ClusterName: cluster
 ID: null
 IGName: master-c
@@ -1037,6 +1049,7 @@ Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-a
 ClusterName: cluster
 ID: null
 IGName: node-a
@@ -1046,6 +1059,7 @@ Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-b
 ClusterName: cluster
 ID: null
 IGName: node-b
@@ -1055,6 +1069,7 @@ Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-c
 ClusterName: cluster
 ID: null
 IGName: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-bastion.yaml
@@ -132,6 +132,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-a
   ClusterName: cluster
   ID: null
   IGName: master-a
@@ -219,6 +220,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-b
   ClusterName: cluster
   ID: null
   IGName: master-b
@@ -306,6 +308,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-c
   ClusterName: cluster
   ID: null
   IGName: master-c
@@ -384,6 +387,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-a
   ClusterName: cluster
   ID: null
   IGName: node-a
@@ -462,6 +466,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-b
   ClusterName: cluster
   ID: null
   IGName: node-b
@@ -540,6 +545,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-c
   ClusterName: cluster
   ID: null
   IGName: node-c
@@ -911,6 +917,7 @@ Tags:
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master-a
 ClusterName: cluster
 ID: null
 IGName: master-a
@@ -920,6 +927,7 @@ Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-b
 ClusterName: cluster
 ID: null
 IGName: master-b
@@ -929,6 +937,7 @@ Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-c
 ClusterName: cluster
 ID: null
 IGName: master-c
@@ -938,6 +947,7 @@ Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-a
 ClusterName: cluster
 ID: null
 IGName: node-a
@@ -947,6 +957,7 @@ Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-b
 ClusterName: cluster
 ID: null
 IGName: node-b
@@ -956,6 +967,7 @@ Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-c
 ClusterName: cluster
 ID: null
 IGName: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/multizone-setup-3-masters-3-nodes-without-external-router.yaml
@@ -84,6 +84,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-a
   ClusterName: cluster
   ID: null
   IGName: master-a
@@ -165,6 +166,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-b
   ClusterName: cluster
   ID: null
   IGName: master-b
@@ -246,6 +248,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master-c
   ClusterName: cluster
   ID: null
   IGName: master-c
@@ -318,6 +321,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-a
   ClusterName: cluster
   ID: null
   IGName: node-a
@@ -390,6 +394,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-b
   ClusterName: cluster
   ID: null
   IGName: node-b
@@ -462,6 +467,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node-c
   ClusterName: cluster
   ID: null
   IGName: node-c
@@ -833,6 +839,7 @@ Tags:
 - KopsName=port-node-c-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master-a
 ClusterName: cluster
 ID: null
 IGName: master-a
@@ -842,6 +849,7 @@ Name: cluster-master-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-b
 ClusterName: cluster
 ID: null
 IGName: master-b
@@ -851,6 +859,7 @@ Name: cluster-master-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master-c
 ClusterName: cluster
 ID: null
 IGName: master-c
@@ -860,6 +869,7 @@ Name: cluster-master-c
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-a
 ClusterName: cluster
 ID: null
 IGName: node-a
@@ -869,6 +879,7 @@ Name: cluster-node-a
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-b
 ClusterName: cluster
 ID: null
 IGName: node-b
@@ -878,6 +889,7 @@ Name: cluster-node-b
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node-c
 ClusterName: cluster
 ID: null
 IGName: node-c

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion-2.yaml
@@ -65,6 +65,7 @@ Role: Bastion
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-bastion
   ClusterName: cluster
   ID: null
   IGName: bastion
@@ -146,6 +147,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -218,6 +220,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -454,6 +457,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-bastion
 ClusterName: cluster
 ID: null
 IGName: bastion
@@ -463,6 +467,7 @@ Name: cluster-bastion
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master
 ClusterName: cluster
 ID: null
 IGName: master
@@ -472,6 +477,7 @@ Name: cluster-master
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-one-bastion.yaml
@@ -85,6 +85,7 @@ Role: Bastion
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-bastion
   ClusterName: cluster
   ID: null
   IGName: bastion
@@ -172,6 +173,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -244,6 +246,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -480,6 +483,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-bastion
 ClusterName: cluster
 ID: null
 IGName: bastion
@@ -489,6 +493,7 @@ Name: cluster-bastion
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-master
 ClusterName: cluster
 ID: null
 IGName: master
@@ -498,6 +503,7 @@ Name: cluster-master
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node-without-bastion-no-public-ip-association.yaml
@@ -72,6 +72,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -144,6 +145,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -339,6 +341,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master
 ClusterName: cluster
 ID: null
 IGName: master
@@ -348,6 +351,7 @@ Name: cluster-master
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/one-master-one-node.yaml
@@ -92,6 +92,7 @@ Role: Master
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-master
   ClusterName: cluster
   ID: null
   IGName: master
@@ -170,6 +171,7 @@ Role: Node
 SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups: null
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -365,6 +367,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-master
 ClusterName: cluster
 ID: null
 IGName: master
@@ -374,6 +377,7 @@ Name: cluster-master
 Policies:
 - anti-affinity
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-subnet-as-availability-zones-fallback.yaml
@@ -62,6 +62,7 @@ SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups:
 - additional-sg
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -211,6 +212,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
+++ b/pkg/model/openstackmodel/tests/servergroup/uses-instance-group-zones-as-availability-zones.yaml
@@ -62,6 +62,7 @@ SSHKey: kubernetes.cluster-ba_d8_85_a0_5b_50_b0_01_e0_b2_b0_ae_5d_f6_7a_d1
 SecurityGroups:
 - additional-sg
 ServerGroup:
+  BackingSGName: cluster-node
   ClusterName: cluster
   ID: null
   IGName: node
@@ -211,6 +212,7 @@ Tags:
 - KopsName=port-node-1
 - KubernetesCluster=cluster
 ---
+BackingSGName: cluster-node
 ClusterName: cluster
 ID: null
 IGName: node

--- a/upup/pkg/fi/cloudup/openstack/cloud.go
+++ b/upup/pkg/fi/cloudup/openstack/cloud.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -331,6 +332,7 @@ type openstackCloud struct {
 	zones           []string
 	floatingEnabled bool
 	useVIPACL       *bool
+	mutex           sync.Mutex
 }
 
 var _ fi.Cloud = &openstackCloud{}

--- a/upup/pkg/fi/cloudup/openstack/instance.go
+++ b/upup/pkg/fi/cloudup/openstack/instance.go
@@ -40,6 +40,7 @@ const (
 	BOOT_FROM_VOLUME          = "osVolumeBoot"
 	BOOT_VOLUME_SIZE          = "osVolumeSize"
 	SERVER_GROUP_AFFINITY     = "serverGroupAffinity"
+	BACKING_SERVER_GROUP_NAME = "backingServerGroupName"
 )
 
 // floatingBackoff is the backoff strategy for listing openstack floatingips

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -32,17 +32,18 @@ import (
 )
 
 func (c *openstackCloud) CreateServerGroup(opt servergroups.CreateOptsBuilder) (*servergroups.ServerGroup, error) {
-	// TODO(sprietl): mutex + if server group exits -> return existing
+	// TODO(sprietl): mutex + if server group exists -> return existing
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
 
-	// servergroups, err := os.osCloud.ListServerGroups(servergroups.ListOpts{})
-	servergroups, err := c.ListServerGroups(servergroups.ListOpts{})
+	serverGroups, err := c.ListServerGroups(servergroups.ListOpts{})
 	if err == nil {
 		return nil, err
 	}
 
-	name = servergroups.CreateOpts.(opt)
+	name := opt.(servergroups.CreateOpts).Name
 
-	for _, sg := range servergroups {
+	for _, sg := range serverGroups {
 		if name == sg.Name {
 			return &sg, nil
 		}

--- a/upup/pkg/fi/cloudup/openstack/server_group.go
+++ b/upup/pkg/fi/cloudup/openstack/server_group.go
@@ -33,11 +33,12 @@ import (
 
 func (c *openstackCloud) CreateServerGroup(opt servergroups.CreateOptsBuilder) (*servergroups.ServerGroup, error) {
 	// TODO(sprietl): mutex + if server group exists -> return existing
+	klog.Infof("CreateServerGroup: %v", opt.(servergroups.CreateOpts))
 	c.mutex.Lock()
 	defer c.mutex.Unlock()
 
 	serverGroups, err := c.ListServerGroups(servergroups.ListOpts{})
-	if err == nil {
+	if err != nil {
 		return nil, err
 	}
 
@@ -101,82 +102,112 @@ func listServerGroups(c OpenstackCloud, opts servergroups.ListOptsBuilder) ([]se
 }
 
 // matchInstanceGroup filters a list of instancegroups for recognized cloud groups
-func matchInstanceGroup(name string, clusterName string, instancegroups []*kops.InstanceGroup) (*kops.InstanceGroup, error) {
-	var instancegroup *kops.InstanceGroup
+func matchInstanceGroup(name string, clusterName string, instancegroups []*kops.InstanceGroup) ([]*kops.InstanceGroup, error) {
+	var results []*kops.InstanceGroup
+
 	for _, g := range instancegroups {
 		var groupName string
+		// var hasBackingSG bool
+		var backingGroupName string
 
 		switch g.Spec.Role {
 		case kops.InstanceGroupRoleMaster, kops.InstanceGroupRoleNode, kops.InstanceGroupRoleBastion:
+			groupName = clusterName + "-" + g.ObjectMeta.Name
 			if v, ok := g.ObjectMeta.Annotations[OS_ANNOTATION+BACKING_SERVER_GROUP_NAME]; ok {
-				groupName = clusterName + "-" + v
+				backingGroupName = clusterName + "-" + v
 			} else {
-				groupName = clusterName + "-" + g.ObjectMeta.Name
+				backingGroupName = ""
 			}
+
+			// if v, ok := g.ObjectMeta.Annotations[OS_ANNOTATION+BACKING_SERVER_GROUP_NAME]; ok {
+			// 	groupName = clusterName + "-" + v
+			// 	hasBackingSG = true
+			// } else {
+			// 	groupName = clusterName + "-" + g.ObjectMeta.Name
+			// 	hasBackingSG = false
+			// }
 		default:
 			klog.Warningf("Ignoring InstanceGroup of unknown role %q", g.Spec.Role)
 			continue
 		}
 
-		if name == groupName {
-			if instancegroup != nil {
+		if name == groupName || name == backingGroupName {
+			klog.Infof("matchInstanceGroup()::match for IG %s: %s == (%s || %s)", g.ObjectMeta.Name, name, groupName, backingGroupName)
+			//if results != nil && !hasBackingSG {
+			if results != nil && backingGroupName == "" {
+				klog.Errorf("matchInstanceGroup()::found multiple instance groups matching servergrp %q", groupName)
 				return nil, fmt.Errorf("found multiple instance groups matching servergrp %q", groupName)
+			} else if results != nil && backingGroupName != "" {
+				klog.Infof("matchInstanceGroup()::found multiple instance groups matching servergrp %q, allowing it due to backingSG %s", groupName, backingGroupName)
 			}
-			instancegroup = g
+			results = append(results, g)
 		}
 	}
 
-	return instancegroup, nil
+	return results, nil
 }
 
-func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops.InstanceGroup, g *servergroups.ServerGroup, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
-	newLaunchConfigName := g.Name
+func osBuildCloudInstanceGroup(c OpenstackCloud, cluster *kops.Cluster, ig *kops.InstanceGroup, grps []servergroups.ServerGroup, nodeMap map[string]*v1.Node) (*cloudinstances.CloudInstanceGroup, error) {
+	// newLaunchConfigName := g.Name
+	newLaunchConfigName := cluster.ObjectMeta.Name + "-" + ig.ObjectMeta.Name
 	cg := &cloudinstances.CloudInstanceGroup{
 		HumanName:     newLaunchConfigName,
 		InstanceGroup: ig,
 		MinSize:       int(fi.Int32Value(ig.Spec.MinSize)),
 		TargetSize:    int(fi.Int32Value(ig.Spec.MinSize)), // TODO: Retrieve the target size from OpenStack?
 		MaxSize:       int(fi.Int32Value(ig.Spec.MaxSize)),
-		Raw:           g,
+		Raw:           grps, // TODO: can we attach a slice here?
 	}
-	for _, i := range g.Members {
-		instanceId := i
-		if instanceId == "" {
-			klog.Warningf("ignoring instance with no instance id: %s", i)
-			continue
-		}
-		server, err := servers.Get(c.ComputeClient(), instanceId).Extract()
-		if err != nil {
-			return nil, fmt.Errorf("Failed to get instance group member: %v", err)
-		}
-		igObservedGeneration := server.Metadata[INSTANCE_GROUP_GENERATION]
-		clusterObservedGeneration := server.Metadata[CLUSTER_GENERATION]
-		observedName := fmt.Sprintf("%s-%s", clusterObservedGeneration, igObservedGeneration)
-		generationName := fmt.Sprintf("%d-%d", cluster.GetGeneration(), ig.Generation)
 
-		status := cloudinstances.CloudInstanceStatusUpToDate
-		if generationName != observedName {
-			status = cloudinstances.CloudInstanceStatusNeedsUpdate
+	for _, g := range grps {
+		klog.Infof("osBuildCloudInstanceGroup()::g.Members: %v", g.Members)
+		for _, i := range g.Members {
+			instanceId := i
+			if instanceId == "" {
+				klog.Warningf("ignoring instance with no instance id: %s", i)
+				continue
+			}
+			server, err := servers.Get(c.ComputeClient(), instanceId).Extract()
+			if err != nil {
+				return nil, fmt.Errorf("Failed to get instance group member: %v", err)
+			}
+
+			actualIG := server.Metadata[TagKopsInstanceGroup]
+			if actualIG != ig.ObjectMeta.Name {
+				klog.Infof("ignoring instance %s (%s), which is not part of IG %s but is part of backingSG %s", server.Name, i, ig.ObjectMeta.Name, g.Name)
+				continue
+			}
+
+			igObservedGeneration := server.Metadata[INSTANCE_GROUP_GENERATION]
+			clusterObservedGeneration := server.Metadata[CLUSTER_GENERATION]
+			observedName := fmt.Sprintf("%s-%s", clusterObservedGeneration, igObservedGeneration)
+			generationName := fmt.Sprintf("%d-%d", cluster.GetGeneration(), ig.Generation)
+
+			status := cloudinstances.CloudInstanceStatusUpToDate
+			if generationName != observedName {
+				status = cloudinstances.CloudInstanceStatusNeedsUpdate
+			}
+			cm, err := cg.NewCloudInstance(instanceId, status, nodeMap[instanceId])
+			if err != nil {
+				return nil, fmt.Errorf("error creating cloud instance group member: %v", err)
+			}
+
+			if server.Flavor["original_name"] != nil {
+				cm.MachineType = server.Flavor["original_name"].(string)
+			}
+
+			ip, err := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
+			if err != nil {
+				return nil, fmt.Errorf("error creating cloud instance group member: %v", err)
+			}
+
+			cm.PrivateIP = ip
+
+			cm.Roles = []string{server.Metadata["KopsRole"]}
+
 		}
-		cm, err := cg.NewCloudInstance(instanceId, status, nodeMap[instanceId])
-		if err != nil {
-			return nil, fmt.Errorf("error creating cloud instance group member: %v", err)
-		}
-
-		if server.Flavor["original_name"] != nil {
-			cm.MachineType = server.Flavor["original_name"].(string)
-		}
-
-		ip, err := GetServerFixedIP(server, server.Metadata[TagKopsNetwork])
-		if err != nil {
-			return nil, fmt.Errorf("error creating cloud instance group member: %v", err)
-		}
-
-		cm.PrivateIP = ip
-
-		cm.Roles = []string{server.Metadata["KopsRole"]}
-
 	}
+	klog.Infof("osBuildCloudInstanceGroup()::cg: %+v", cg)
 	return cg, nil
 }
 

--- a/upup/pkg/fi/cloudup/openstacktasks/instance.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/instance.go
@@ -324,6 +324,7 @@ func (_ *Instance) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, change
 			KeyName:           openstackKeyPairName(fi.StringValue(e.SSHKey)),
 		}
 
+		// TODO(sprietl): instead of *e.ServerGroup.ID -> our servergroup gen with pulumi
 		sgext := schedulerhints.CreateOptsExt{
 			CreateOptsBuilder: keyext,
 			SchedulerHints: &schedulerhints.SchedulerHints{

--- a/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
+++ b/upup/pkg/fi/cloudup/openstacktasks/servergroup.go
@@ -140,6 +140,7 @@ func (_ *ServerGroup) RenderOpenstack(t *openstack.OpenstackAPITarget, a, e, cha
 		if err != nil {
 			return fmt.Errorf("error creating ServerGroup: %v", err)
 		}
+		klog.Infof("the server group for %v: %v", e, g)
 		e.ID = fi.String(g.ID)
 		return nil
 	} else if changes.MaxSize != nil && fi.Int32Value(a.MaxSize) > fi.Int32Value(changes.MaxSize) {


### PR DESCRIPTION
This aims to introduce a functionality to provide one servergroup for masters on OpenStack instances without Availability Zones.

Normally, the different server groups of the masters would map to a certain availability zone in OpenStack and thus the masters won't be able to run on the same hypervisor. Sadly, this is not true if there is only one availability zone and since the masters are all in a separate server group in OpenStack they are allowed to run on the same hypervisors.

Unfortunately, it is not possible to create something like a Meta Group in OpenStack (at least not to my knowledge), and thus the functionality has to be incorporated into kops.

Since there is a 1:1 mapping of IG to server groups, and masters require - according to the docs - different Instance Groups (one being in each group, b/c etcd is setup per AZ/IG: https://kops.sigs.k8s.io/tutorial/working-with-instancegroups/#instance-groups-disclaimer), I tried to implement this functionality through "the back door", by letting users specify a "backing Server Group" (for now this is for all the server groups, this probably should be restricted to master groups only, and also validated, etc.).

This will still create a normal server group for each master in the kops state, but the it will reference to one server group in OpenStack.

With that said: The implementation is still somewhat awkward and messy, and it really looks like kops "does not like" them server groups being changed around.