### PR TITLE
Add custom CI to release-1.24-bp

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -33,3 +33,8 @@ jobs:
           invalid-labels: 'do-not-merge, wip, wait-before-merge'
           disable-reviews: true
           github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Enable auto merge
+        uses: alexwilson/enable-github-automerge-action@main
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,35 @@
+name: Check PR
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - synchronize
+    branches:
+      - 'master*'
+      - 'release*'
+
+jobs:
+  check-pr:
+    name: Check PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit messages for WIP
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(?!WIP)'
+          flags: 'gmi'
+          error: Work in progress
+          checkAllCommitMessages: true
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check PR labels
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          valid-labels: 'merge'
+          invalid-labels: 'do-not-merge, wip, wait-before-merge'
+          disable-reviews: true
+          github-token: '${{ secrets.GITHUB_TOKEN }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,25 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Detect changes
+      uses: dorny/paths-filter@v2
+      id: filter
+      with:
+        filters: |
+          src:
+            - '!.github/**'
+
   build-linux-amd64:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
@@ -56,6 +74,8 @@ jobs:
           retention-days: 1
 
   build-macos-amd64:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: macos-10.15
     steps:
       - name: Set up go
@@ -91,6 +111,8 @@ jobs:
           retention-days: 1
 
   build-windows-amd64:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: windows-2019
     steps:
       - name: Set up go
@@ -126,6 +148,8 @@ jobs:
           retention-days: 1
 
   verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
 
   build-linux-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
@@ -73,7 +73,7 @@ jobs:
 
   build-macos-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: macos-10.15
     steps:
       - name: Set up go
@@ -108,7 +108,7 @@ jobs:
 
   build-windows-amd64:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: windows-2019
     steps:
       - name: Set up go
@@ -143,7 +143,7 @@ jobs:
 
   verify:
     needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' }}
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,41 +106,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  build-windows-amd64:
-    needs: changes
-    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
-    runs-on: windows-2019
-    steps:
-      - name: Set up go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.18.1
-
-      - name: Checkout full
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
-
-      - name: Checkout shallow
-        uses: actions/checkout@v2
-        if: startsWith(github.ref, 'refs/tags/') == false
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-
-      - name: Make kops examples test
-        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-        run: |
-          make kops examples test-windows
-
-      - name: Upload windows binary
-        if: startsWith(github.ref, 'refs/tags/')
-        uses: actions/upload-artifact@v2
-        with:
-          name: kops-windows-amd64
-          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/local/kops
-          if-no-files-found: error
-          retention-days: 1
-
   verify:
     needs: changes
     if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
@@ -167,7 +132,6 @@ jobs:
     needs:
       - build-linux-amd64
       - build-macos-amd64
-      - build-windows-amd64
       - verify
     steps:
       - name: Download all kops binary artifacts
@@ -177,7 +141,6 @@ jobs:
         run: |
           mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
           mv kops-darwin-amd64/kops kops-darwin-amd64/kops-darwin-amd64
-          mv kops-windows-amd64/kops kops-windows-amd64/kops-windows-amd64
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -186,4 +149,3 @@ jobs:
           files: |
             kops-linux-amd64/kops-linux-amd64
             kops-darwin-amd64/kops-darwin-amd64
-            kops-windows-amd64/kops-windows-amd64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,11 +47,9 @@ jobs:
           go-version: 1.18.1
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2
@@ -84,11 +82,9 @@ jobs:
           go-version: 1.18.1
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2
@@ -121,11 +117,9 @@ jobs:
           go-version: 1.18.1
 
       - name: Checkout full
-        uses: actions/checkout@v2
         if: startsWith(github.ref, 'refs/tags/')
-        with:
-          path: ${{ env.GOPATH }}/src/k8s.io/kops
-          fetch-depth: 0
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
       - name: Checkout shallow
         uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,16 @@
----
 name: CI
 
-'on':
-  - push
-  - pull_request
+on:
+  push:
+    tags:
+      - '*'
+    branches:
+      - 'master*'
+      - 'release*'
+  pull_request:
+    branches:
+      - 'master*'
+      - 'release*'
 
 env:
   GOPROXY: https://proxy.golang.org
@@ -21,48 +28,102 @@ jobs:
         with:
           go-version: 1.18.1
 
-      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
+      - name: Checkout full
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
+          fetch-depth: 0
+
+      - name: Checkout shallow
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/') == false
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-      - name: make all examples test
+      - name: Make all examples test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
           make all examples test
 
+      - name: Upload Linux binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v2
+        with:
+          name: kops-linux-amd64
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/local/kops
+          if-no-files-found: error
+          retention-days: 1
+
   build-macos-amd64:
     runs-on: macos-10.15
     steps:
-    - name: Set up go
-      uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
-      with:
-        go-version: 1.18.1
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.1
 
-    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kops
+      - name: Checkout full
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
+          fetch-depth: 0
 
-    - name: make kops examples test
-      working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-      run: |
-        make kops examples test
+      - name: Checkout shallow
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/') == false
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Make kops examples test
+        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
+        run: |
+          make kops examples test
+
+      - name: Upload macos binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v2
+        with:
+          name: kops-darwin-amd64
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/local/kops
+          if-no-files-found: error
+          retention-days: 1
 
   build-windows-amd64:
     runs-on: windows-2019
     steps:
-    - name: Set up go
-      uses: actions/setup-go@b22fbbc2921299758641fab08929b4ac52b32923
-      with:
-        go-version: 1.18.1
+      - name: Set up go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.18.1
 
-    - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kops
+      - name: Checkout full
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
+          fetch-depth: 0
 
-    - name: make kops examples test
-      working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-      run: |
-        make kops examples test-windows
+      - name: Checkout shallow
+        uses: actions/checkout@v2
+        if: startsWith(github.ref, 'refs/tags/') == false
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Make kops examples test
+        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
+        run: |
+          make kops examples test-windows
+
+      - name: Upload windows binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v2
+        with:
+          name: kops-windows-amd64
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/local/kops
+          if-no-files-found: error
+          retention-days: 1
 
   verify:
     runs-on: ubuntu-20.04
@@ -72,11 +133,39 @@ jobs:
         with:
           go-version: 1.18.1
 
-      - uses: actions/checkout@629c2de402a417ea7690ca6ce3f33229e27606a5 # v2 https://api.github.com/repos/actions/checkout/git/tags/629c2de402a417ea7690ca6ce3f33229e27606a5
+      - name: Checkout repository
+        uses: actions/checkout@v2
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-      - name: make quick-ci
+      - name: Make quick-ci
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
           make quick-ci
+
+  release:
+    runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags/')
+    needs:
+      - build-linux-amd64
+      - build-macos-amd64
+      - build-windows-amd64
+      - verify
+    steps:
+      - name: Download all kops binary artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Rename kops binary artifacts
+        run: |
+          mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
+          mv kops-darwin-amd64/kops kops-darwin-amd64/kops-darwin-amd64
+          mv kops-windows-amd64/kops kops-windows-amd64/kops-windows-amd64
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            kops-linux-amd64/kops-linux-amd64
+            kops-darwin-amd64/kops-darwin-amd64
+            kops-windows-amd64/kops-windows-amd64

--- a/tools/get_version.sh
+++ b/tools/get_version.sh
@@ -36,6 +36,7 @@ if [[ -n "${CI}" ]]; then
     EXACT_TAG=$(git describe --tags --exact-match 2>/dev/null || true)
     if [[ -n "${EXACT_TAG}" ]]; then
         VERSION="${EXACT_TAG#v}" # Remove the v prefix from the git tag
+        VERSION="${VERSION//-bp*/}" # remove the bearingpoint version from the tag
         if [[ "${VERSION}" != "${KOPS_RELEASE_VERSION}" ]]; then
             echo "Build was tagged with ${VERSION}, but version.go had version ${KOPS_RELEASE_VERSION}"
             exit 1


### PR DESCRIPTION
Cherry pick of #1 #2 #4 #5 on release-1.20-bp.

#1: Improve CI and release workflow
#2: Check PR with workflow
#4: Enable auto merge via workflow
#5: Run CI only on actual code changes
#37: Use git clone for full checkout