### PR TITLE
Adapt CI workflow for release-1.26-bp

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -1,0 +1,40 @@
+name: Check PR
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - labeled
+      - unlabeled
+      - reopened
+      - synchronize
+    branches:
+      - 'master*'
+      - 'release*'
+
+jobs:
+  check-pr:
+    name: Check PR
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check commit messages for WIP
+        uses: gsactions/commit-message-checker@v1
+        with:
+          pattern: '^(?!WIP)'
+          flags: 'gmi'
+          error: Work in progress
+          checkAllCommitMessages: true
+          accessToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check PR labels
+        uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          valid-labels: 'merge'
+          invalid-labels: 'do-not-merge, wip, wait-before-merge'
+          disable-reviews: true
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+
+      - name: Enable auto merge
+        uses: alexwilson/enable-github-automerge-action@main
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,16 @@
----
 name: CI
 
-'on':
-  - push
-  - pull_request
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - "master*"
+      - "release*"
+  pull_request:
+    branches:
+      - "master*"
+      - "release*"
 
 env:
   GOPROXY: https://proxy.golang.org
@@ -13,70 +20,134 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+
+      - name: Detect changes
+        uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            src:
+              - '!.github/**'
+
   build-linux-amd64:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.7'
+          go-version: "1.19.7"
 
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - name: Checkout full
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
+
+      - name: Checkout shallow
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        if: startsWith(github.ref, 'refs/tags/') == false
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-      - name: make all examples test
+      - name: Make all examples test
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
           make all examples test
 
+      - name: Upload Linux binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v3
+        with:
+          name: kops-linux-amd64
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/dist/linux/amd64/kops
+          if-no-files-found: error
+          retention-days: 1
+
   build-macos-amd64:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: macos-latest
     steps:
-    - name: Set up go
-      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
-      with:
-        go-version: '1.19.7'
+      - name: Set up go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
+        with:
+          go-version: "1.19.7"
 
-    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kops
+      - name: Checkout full
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          git clone ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY} -b ${GITHUB_REF#refs/tags/} ${{ env.GOPATH }}/src/k8s.io/kops
 
-    - name: make kops examples test
-      working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-      run: |
-        make kops examples test
+      - name: Checkout shallow
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+        if: startsWith(github.ref, 'refs/tags/') == false
+        with:
+          path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-  build-windows-amd64:
-    runs-on: windows-2019
-    steps:
-    - name: Set up go
-      uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
-      with:
-        go-version: '1.19.7'
+      - name: Make kops examples test
+        working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
+        run: |
+          make kops examples test
 
-    - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
-      with:
-        path: ${{ env.GOPATH }}/src/k8s.io/kops
-
-    - name: make kops examples test
-      working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
-      run: |
-        make kops examples test-windows
+      - name: Upload macos binary
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: actions/upload-artifact@v3
+        with:
+          name: kops-darwin-amd64
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/dist/darwin/amd64/kops
+          if-no-files-found: error
+          retention-days: 1
 
   verify:
+    needs: changes
+    if: ${{ needs.changes.outputs.src == 'true' || startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Set up go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568
         with:
-          go-version: '1.19.7'
+          go-version: "1.19.7"
 
-      - uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b
+      - name: Checkout repository
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           path: ${{ env.GOPATH }}/src/k8s.io/kops
 
-      - name: make quick-ci
+      - name: Make quick-ci
         working-directory: ${{ env.GOPATH }}/src/k8s.io/kops
         run: |
           make quick-ci
+
+  release:
+    runs-on: ubuntu-20.04
+    if: startsWith(github.ref, 'refs/tags/')
+    permissions:
+      contents: write
+    needs:
+      - build-linux-amd64
+      - build-macos-amd64
+      - verify
+    steps:
+      - name: Download all kops binary artifacts
+        uses: actions/download-artifact@v2
+
+      - name: Rename kops binary artifacts
+        run: |
+          mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
+          mv kops-darwin-amd64/kops kops-darwin-amd64/kops-darwin-amd64
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          fail_on_unmatched_files: true
+          files: |
+            kops-linux-amd64/kops-linux-amd64
+            kops-darwin-amd64/kops-darwin-amd64

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,12 +62,12 @@ jobs:
         run: |
           make all examples test
 
-      - name: Upload Linux binary
+      - name: Upload Linux binaries
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v3
         with:
           name: kops-linux-amd64
-          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/dist/linux/amd64/kops
+          path: ${{ env.GOPATH }}/src/k8s.io/kops/.build/dist/linux/amd64/*
           if-no-files-found: error
           retention-days: 1
 
@@ -97,7 +97,7 @@ jobs:
         run: |
           make kops examples test
 
-      - name: Upload macos binary
+      - name: Upload kops MacOS binary
         if: startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v3
         with:
@@ -136,18 +136,24 @@ jobs:
       - build-macos-amd64
       - verify
     steps:
-      - name: Download all kops binary artifacts
+      - name: Download all binary artifacts
         uses: actions/download-artifact@v2
 
       - name: Rename kops binary artifacts
         run: |
-          mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
           mv kops-darwin-amd64/kops kops-darwin-amd64/kops-darwin-amd64
+          mv kops-linux-amd64/kops kops-linux-amd64/kops-linux-amd64
+          mv kops-linux-amd64/channels kops-linux-amd64/channels-linux-amd64
+          mv kops-linux-amd64/protokube kops-linux-amd64/protokube-linux-amd64
+          mv kops-linux-amd64/nodeup kops-linux-amd64/nodeup-linux-amd64
 
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           fail_on_unmatched_files: true
           files: |
-            kops-linux-amd64/kops-linux-amd64
             kops-darwin-amd64/kops-darwin-amd64
+            kops-linux-amd64/kops-linux-amd64
+            kops-linux-amd64/channels-linux-amd64
+            kops-linux-amd64/protokube-linux-amd64
+            kops-linux-amd64/nodeup-linux-amd64

--- a/tools/get_version.sh
+++ b/tools/get_version.sh
@@ -36,6 +36,7 @@ if [[ -n "${CI}" ]]; then
     EXACT_TAG=$(git describe --tags --exact-match 2>/dev/null || true)
     if [[ -n "${EXACT_TAG}" ]]; then
         VERSION="${EXACT_TAG#v}" # Remove the v prefix from the git tag
+        VERSION="${VERSION//-bp*/}" # remove the bearingpoint version from the tag
         if [[ "${VERSION}" != "${KOPS_RELEASE_VERSION}" ]]; then
             echo "Build was tagged with ${VERSION}, but kops-version.go had version ${KOPS_RELEASE_VERSION}"
             exit 1


### PR DESCRIPTION
This adapts the CI workflow for the `-bp` branches:
* Add PR check
* Adapt CI workflow to to include `release` job.